### PR TITLE
perf: exclude the inline source map from production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,11 @@
 const path = require('path');
 
-module.exports = {
+module.exports = (env, argv) => ({
   entry: './src/index.ts',
-  devtool: 'inline-source-map',
-  mode: 'development',
+  // Inline source maps are ~1.6 MB and would be embedded in the bundle that
+  // every Home Assistant page loads, so keep them out of production builds.
+  devtool: argv.mode === 'production' ? false : 'inline-source-map',
+  mode: argv.mode || 'development',
   module: {
     rules: [
       {
@@ -20,4 +22,4 @@ module.exports = {
     filename: 'sip_core.js',
     path: path.resolve(__dirname, 'custom_components', 'sip_core', 'www'),
   },
-};
+});


### PR DESCRIPTION
#### TLDR

The published `sip_core.js` is 84% inline source map — 1.65 MB of the 1.95 MB that every
Home Assistant page loads. Not shipping the source map in release builds takes it down to
305 KB, with no runtime change.

### The problem

`webpack.config.js` hardcodes `devtool: 'inline-source-map'`. The build script passes
`--mode production`, which overrides the `mode` field but **not** `devtool` — so the
published bundle ends up minified *and* still carrying a full base64 source map.

It matters more than usual here because the integration registers as a global Lovelace
resource and self-initializes at module scope to receive incoming calls, so the file is
loaded on every page, not just where a SIP card is used.

### The change

Production builds no longer emit a source map. Development builds still get inline maps,
so `npm run watch` is unaffected.

| | before | after | |
|---|---|---|---|
| `npm run build` | 1,955,448 B | 305,379 B | **-84%** |
| gzipped | 409,047 B | 70,723 B | **-83%** |
| `--mode development` | 2,671,060 B | unchanged | maps still present |

### Risk

Low — bundler output only, no runtime code touched. The one trade is that you can no longer
read original sources from a production bundle in devtools.
