### PR TITLE
fix: open the call popup for calls started by the ?call= autocall

### DIFF
--- a/src/sip-call-dialog.ts
+++ b/src/sip-call-dialog.ts
@@ -256,6 +256,16 @@ class SIPCallDialog extends LitElement {
         if (this.config.auto_open !== false) {
             window.addEventListener("sipcore-call-started", this.openPopup);
             window.addEventListener("sipcore-call-ended", this.closePopup);
+            // `sipcore-call-started` is dispatched as soon as the session is
+            // created, which can be before this element has been upgraded: the
+            // `?call=` autocall dials straight from `init()`, while the custom
+            // element is still only a placeholder appended by `setupPopup()`.
+            // The event is then missed and the popup never opens, leaving an
+            // active call with no way to hang up. Catch up on a call that is
+            // already in progress rather than relying on the event ordering.
+            if (sipCore.callState !== CALLSTATE.IDLE) {
+                this.openPopup();
+            }
         } else {
             window.addEventListener("sipcore-call-started", this.updateHandler);
             window.addEventListener("sipcore-call-ended", this.updateHandler);


### PR DESCRIPTION
#### TLDR

A call placed by the `?call=<extension>` autocall connects, but the popup never opens — so
there is no hangup button and no way to end the call from the UI. The autocall dials from
`init()`, before `sip-call-dialog` has been upgraded and subscribed to
`sipcore-call-started`, so the event is dispatched into the void. Let the popup open itself
when it finds a call already in progress, instead of depending on the event arriving first.

### The problem

`init()` appends the popup element and then dials, in the same run:

```ts
if (this.config.popup_config !== null) {
    this.setupPopup();          // document.body.appendChild(createElement("sip-call-dialog"))
}
this.triggerUpdate();

// autocall if set
const autocall_extension = new URLSearchParams(window.location.search).get("call");
if (autocall_extension) {
    this.startCall(autocall_extension);
}
```

`setupPopup()` only puts the tag in the DOM. Until the custom element is *defined*, that tag
is an inert placeholder: `connectedCallback` has not run, so
`window.addEventListener("sipcore-call-started", this.openPopup)` has not happened either.
`startCall()` reaches `ua.call()`, `newRTCSession` fires, `sipcore-call-started` is
dispatched — and nobody is listening.

Measured in Chrome on a real Home Assistant dashboard, times relative to navigation start:

| event | t |
|---|---|
| control listener attached by the test harness | 89 ms |
| `<sip-call-dialog>` appended by `setupPopup()` (not yet upgraded) | 1242 ms |
| **`sipcore-call-started` dispatched** | **3257 ms** |
| **`sip-call-dialog` defined, `connectedCallback` runs** | **3369 ms** |
| `dialog.open` becomes true | never |

The component is defined **112 ms after** the event it was supposed to receive. `open` stays
`false` for the entire call. Dispatching the same event by hand once the page has settled
opens the popup correctly, which confirms the listener itself is fine — it is purely an
ordering problem.

Only the autocall path is affected. Every other caller — the contacts card, the call button,
an incoming call — reaches `startCall()` long after the element is live, which is why this
has gone unnoticed.

### The change

`sip-call-dialog` no longer assumes it was listening when the call began:

```ts
if (this.config.auto_open !== false) {
    window.addEventListener("sipcore-call-started", this.openPopup);
    window.addEventListener("sipcore-call-ended", this.closePopup);
    if (sipCore.callState !== CALLSTATE.IDLE) {
        this.openPopup();
    }
}
```

One file, `src/sip-call-dialog.ts`, inside the existing `auto_open` branch — so a user who
has opted out of `auto_open` keeps the current behaviour.

After the change, same measurement: `dialog.open` is `true` at 951 ms alongside
`callState: "outgoing"`, stays open through `connected`, and closes on `sipcore-call-ended`
when the call ends.

### Why not delay the call instead

The obvious alternative is to hold the autocall until the popup is ready — await
`customElements.whenDefined(...)` and the element's `updateComplete` before dialling. I
built that first and shipped it; it does not work reliably. Any timeout guarding the wait
becomes a new race: with a 2 s cap the call was released at ~3250 ms, still 112 ms before
the component was defined. Removing the cap trades a missed popup for a call that may never
be placed, which is worse for the doorbell use case this feature exists for.

Reacting to the state that already exists removes the race rather than trying to win it, and
needs no timers.

### Reproducing

Open any dashboard as `…/lovelace/0?call=<extension>` in a **cold** tab, with
`auto_open` left at its default. The call connects and the popup never appears. Watch
`document.querySelector("sip-call-dialog").open` — it stays `false`.

Note that a warm SPA navigation will not reproduce it: `init()` only runs on a full page
load, which is also the only case where the autocall fires at all.

### Risk

Low. One conditional in `connectedCallback`, reachable only when a call is already in
progress as the element initialises — which today can only happen via the autocall. No
change to the event contract, no change to the `auto_open: false` path, no timers
introduced.
