### PR TITLE
fix: stop writing SIP account passwords to the Home Assistant log

### DIFF
--- a/custom_components/sip_core/__init__.py
+++ b/custom_components/sip_core/__init__.py
@@ -8,11 +8,16 @@ from homeassistant.components.hassio.const import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.hassio.handler import HassIO, get_supervisor_client
 from homeassistant.helpers.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.redact import async_redact_data
 from .const import ASTERISK_ADDON_SLUG, DOMAIN, JS_FILENAME, JS_URL_PATH
 from .resources import add_resources, remove_resources
 from .defaults import sip_config
 
 logger = logging.getLogger(__name__)
+
+# `sip_config.users[].password` is the SIP account password, sent to the browser
+# so it can register against the PBX. It has no business being written to the log.
+TO_REDACT = {"password"}
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -28,9 +33,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "options": {"sip_config": config_entry.options.get("sip_config", sip_config)},
         "entry_id": config_entry.entry_id,
     })
-    logger.info(config_entry.data)
-    logger.info(config_entry.options)
-    logger.info(config_entry.entry_id)
+    logger.debug(
+        "Config entry %s: data=%s, options=%s",
+        config_entry.entry_id,
+        async_redact_data(config_entry.data, TO_REDACT),
+        async_redact_data(config_entry.options, TO_REDACT),
+    )
 
     await hass.http.async_register_static_paths(
         [


### PR DESCRIPTION
#### TLDR

Every configured SIP account's password is written to `home-assistant.log` in clear text,
at INFO level, on every start and every reload. Redact it, and drop the dump to `debug`.

### The problem

`async_setup_entry` logs the config entry verbatim:

```python
logger.info(config_entry.data)
logger.info(config_entry.options)
logger.info(config_entry.entry_id)
```

`config_entry.options` contains `sip_config`, and `sip_config.users[]` is a list of
`{ha_username, extension, password}`. So a normal startup writes one INFO line containing
every SIP credential on the instance. Observed on a live installation running Home
Assistant 2026.8.3 — the line is present after every restart, with the passwords readable.

This matters more than a log line usually would, because `home-assistant.log` is not a
private artefact:

- it is what users download from Settings → System → Logs and paste into issues and forum
  threads when asking for help;
- it is included in full backups, which are frequently synced off-site;
- it sits on disk at INFO, the default level, so no one has to opt in to produce it.

The passwords are also PBX credentials, not application-local secrets: they authenticate
against Asterisk, which usually reaches the outside world.

### The change

Redact with Home Assistant's own helper and log once, at `debug`:

```python
TO_REDACT = {"password"}

logger.debug(
    "Config entry %s: data=%s, options=%s",
    config_entry.entry_id,
    async_redact_data(config_entry.data, TO_REDACT),
    async_redact_data(config_entry.options, TO_REDACT),
)
```

`homeassistant.helpers.redact.async_redact_data` walks nested mappings *and lists*, so it
reaches `sip_config.users[].password` without the call needing to know the shape of the
config. The three separate dumps become one line, and INFO becomes `debug`: the full
configuration is diagnostic detail, not something every installation should be writing to
its log unprompted.

No compatibility floor is raised. `homeassistant.helpers.redact` is present in 2024.7,
which this integration already requires through its unconditional import of
`StaticPathConfig`.

### Scope

`SipCoreConfigView` still serves the password to the browser. That is by design — the SIP
client running in the page needs it to register against the PBX — and is deliberately left
alone here.

### Risk

Very low. One import, one constant, three log statements replaced by one. No behavioural
change beyond what is written to the log; anyone who actually wants the dump gets it by
enabling `debug` for `custom_components.sip_core`, minus the credentials.

### For maintainers

Users who have already run an affected version have their SIP passwords sitting in their
current and rotated log files, and in any backup taken since. It may be worth saying so in
the release notes so they can rotate the affected extensions rather than only upgrading.
